### PR TITLE
Add an option to follow symbolic links when scanning

### DIFF
--- a/src/main/java/com/suse/pase/cli/Index.java
+++ b/src/main/java/com/suse/pase/cli/Index.java
@@ -14,6 +14,8 @@ import picocli.CommandLine.Parameters;
 public class Index implements Callable<Integer> {
     @Option(names = { "-r", "--recursion-limit" }, paramLabel = "RECURSION_LIMIT", defaultValue = "2", description = "the number of nested archives to unpack")
     int recursionLimit;
+    @Option(names = { "-s", "--follow-symlinks" }, description = "follow symbolic links when indexing")
+    boolean followSymlinks;
     @Parameters(index = "0", paramLabel = "SOURCE_PATH", description = "directory to index")
     Path sourcePath;
     @Parameters(index = "1", paramLabel = "INDEX_PATH", description = "directory where to create the index")
@@ -21,14 +23,14 @@ public class Index implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        index(sourcePath, indexPath, recursionLimit);
+        index(sourcePath, indexPath, recursionLimit, followSymlinks);
         return 0;
     }
 
-    public static void index(Path sourcePath, Path indexPath, int recursionLimit) throws Exception {
+    public static void index(Path sourcePath, Path indexPath, int recursionLimit, boolean followSymlinks) throws Exception {
         System.setProperty("java.util.logging.SimpleFormatter.format", "[%1$tF %1$tT] [%4$s] %5$s %n");
         try (var writer = new IndexWriter(indexPath)) {
-            new DirectoryIndexer(sourcePath, recursionLimit, writer).index();
+            new DirectoryIndexer(sourcePath, recursionLimit, followSymlinks, writer).index();
         }
     }
 }

--- a/src/main/java/com/suse/pase/directory/DirectoryIndexer.java
+++ b/src/main/java/com/suse/pase/directory/DirectoryIndexer.java
@@ -27,15 +27,17 @@ public class DirectoryIndexer {
     private static Logger LOG = Logger.getLogger(DirectoryIndexer.class.getName());
     private final Path root;
     private final int recursionLimit;
+    private final boolean followSymlinks;
     private final IndexWriter index;
     private final AtomicInteger processedFiles = new AtomicInteger();
     private final AtomicInteger processedFilesInArchives = new AtomicInteger();
     private final AtomicInteger updatedFiles = new AtomicInteger();
     private final AtomicInteger updatedFilesInArchives = new AtomicInteger();
 
-    public DirectoryIndexer(Path path, int recursionLimit, IndexWriter index) {
+    public DirectoryIndexer(Path path, int recursionLimit, boolean followSymlinks, IndexWriter index) {
         this.root = path;
         this.recursionLimit = recursionLimit;
+        this.followSymlinks = followSymlinks;
         this.index = index;
     }
 
@@ -45,7 +47,7 @@ public class DirectoryIndexer {
      */
     public void index() {
         Stopwatch timer = Stopwatch.createStarted();
-        new DirectoryWalker(root).walkFiles((path, stream) -> {
+        new DirectoryWalker(root, this.followSymlinks).walkFiles((path, stream) -> {
             var fingerprint = fingerprint(path);
             if (isText(path, stream)) {
                 if (index.add(path.toString(), fingerprint, of(stream))) {

--- a/src/main/java/com/suse/pase/directory/DirectoryWalker.java
+++ b/src/main/java/com/suse/pase/directory/DirectoryWalker.java
@@ -4,13 +4,17 @@ import static java.util.Optional.empty;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -22,10 +26,12 @@ public class DirectoryWalker {
     private static final int BUFFER_SIZE = 4 * 1024 * 1024;
 
     private final Path path;
+    private final boolean followSymlinks;
     private final ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 
-    public DirectoryWalker(Path path) {
+    public DirectoryWalker(Path path, boolean followSymlinks) {
         this.path = path;
+        this.followSymlinks = followSymlinks;
     }
 
     /** Calls the consumer for all files in the directory. The consumer receives each file's path and a stream of its bytes. */
@@ -33,10 +39,14 @@ public class DirectoryWalker {
         try {
             final List<Callable<Object>> todo = new LinkedList<>();
 
-            Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+            Set<FileVisitOption> fileVisitOptions = Collections.emptySet();
+            if (followSymlinks) {
+                fileVisitOptions = EnumSet.of(FileVisitOption.FOLLOW_LINKS);
+            }
+            Files.walkFileTree(path, fileVisitOptions, 200, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path path, BasicFileAttributes attrs) throws IOException {
-                    if (attrs.isRegularFile() && !attrs.isSymbolicLink()) {
+                    if (attrs.isRegularFile() && (followSymlinks || !attrs.isSymbolicLink())) {
                         todo.add(() -> {
                             try (var fileStream = Files.newInputStream(path);
                                  var stream = new BufferedInputStream(fileStream, BUFFER_SIZE)) {

--- a/src/test/java/com/suse/pase/MainTest.java
+++ b/src/test/java/com/suse/pase/MainTest.java
@@ -29,7 +29,7 @@ public class MainTest {
         // get path in random temporary location
         indexPath = createTempDirectory(MainTest.class.getCanonicalName());
 
-        Index.index(sourcePath, indexPath, 2);
+        Index.index(sourcePath, indexPath, 2, false);
     }
 
     @org.junit.jupiter.api.Test


### PR DESCRIPTION
The default behavior is still to ignore symlinks, but if enabled symlinks of
both files and directories will be followed.